### PR TITLE
possible patch on problem starting cassandra

### DIFF
--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -3,6 +3,16 @@
 # script. The application will work only if it binds to
 # $OPENSHIFT_INTERNAL_IP:8080
 set -x
+max_memory_bytes=`oo-cgroup-read memory.limit_in_bytes`
+max_memory_mb=`expr $max_memory_bytes / 1048576`
+CASSANDRA_JVM_HEAP_RATIO=0.5
+CASSANDRA_JVM_HEAP_NEWSIZE=0.25
+max_heap_size_in_mb=$( echo "$max_memory_mb * $CASSANDRA_JVM_HEAP_RATIO" | bc | awk '{print int($1+0.5)}')
+heap_newsize_in_mb=$( echo "$max_memory_mb * $CASSANDRA_JVM_HEAP_NEWSIZE" | bc | awk '{print int($1+0.5)}')
+MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
+HEAP_NEWSIZE="${heap_newsize_in_mb}M"
+export MAX_HEAP_SIZE
+export HEAP_NEWSIZE
 cd $OPENSHIFT_DATA_DIR/cassandra
 bin/cassandra
 export CQLSH_HOST=$OPENSHIFT_DIY_IP

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+Started from https://github.com/shekhargulati/cassandra-openshift-quickstart
+
+It seems to have this isssue: 
+https://github.com/shekhargulati/cassandra-openshift-quickstart/issues/2
+
+Usage is the same as described in *How To Configure and Run Cassandra on OpenShift* 
+https://blog.openshift.com/cassandra-on-openshift/ the only difference is the command:
+
+`git remote add upstream https://github.com/MassimoCappellano/cassandra-openshift-quickstart.git`
+
 The OpenShift `diy` cartridge documentation can be found at:
 
 https://github.com/openshift/origin-server/tree/master/cartridges/openshift-origin-cartridge-diy/README.md


### PR DESCRIPTION
Hi Shekhar,

I've done this patch for my work on cassandra on openshift. It seems to work. I've tested on gear small and medium, and now java (java 7) process is able to allocate memory. A little modification in `start` action_hooks script. 

Thank you for your work.
Massimo
